### PR TITLE
Add: 'body-parser' dependency to lab3

### DIFF
--- a/modules/03.continuous-testing/lab/package.json
+++ b/modules/03.continuous-testing/lab/package.json
@@ -10,6 +10,7 @@
   "author": "Sergei Kudinov",
   "license": "",
   "dependencies": {
+    "body-parser": "^1.20.2",
     "express": "^4.17.2",
     "mixme": "^0.5.4",
     "redis": "^3.1.2"


### PR DESCRIPTION
This pull request adds the 'body-parser' dependency to the lab3 project. This change is necessary because the 'body-parser' middleware is required by the 'index.js' file to handle incoming POST requests and extract data from them.